### PR TITLE
Unit01 revised 3 point alignment

### DIFF
--- a/bin/synspy-pair-csv
+++ b/bin/synspy-pair-csv
@@ -34,15 +34,27 @@ store = HatracStore('https', servername, credentials)
 def get_centroids_measures_from_pair(pair_study, voxel_image_aligner):
     image1 = ImageGrossAlignment.from_image_id(catalog, pair_study._metadata['Image 1'])
 
-    
-    xform = np.matmul(image1.M, voxel_image_aligner.M_inv)
-    
+    xform = None
+
+    if image1.has_standard:
+        # not safe to access these properties if we don't have_standard...
+        if image1.canonical_alignment_standard_image["RID"] == voxel_image_aligner.RID:
+            xform = image1.M_canonical
+        elif image1.alignment_standard_image["RID"] == voxel_image_aligner.RID:
+            # special case: stop at intermediate reference image w/ custom alignment?
+            if image1._metadata["Alignment"]:
+                xform = np.array(image1._metadata["Alignment"], dtype=np.float64)
+
+    if xform is None:
+        # fall back to 3-point alignment
+        xform = np.matmul(image1.M, voxel_image_aligner.M_inv)
+
     s1_to_s2, s2_to_s1 = pair_study.syn_pairing_maps(max_dx_seq=(3.0,), dx_w_ratio=None, max_w_ratio=None)
     s1_only = pair_study.get_unpaired(s1_to_s2[0,:], pair_study.s1)
     s2_only = pair_study.get_unpaired(s2_to_s1[0,:], pair_study.s2)
     s1_pair, s2_pair = pair_study.get_pairs(s1_to_s2[0,:], pair_study.s1, pair_study.s2)
     print('Study %s pairing status: before=%s paired0=%s paired1=%s after=%s' % (
-        pair_study,
+        pair_study.id,
         s1_only.shape,
         s1_pair.shape,
         s2_pair.shape,
@@ -85,10 +97,13 @@ def get_centroids_measures(pair_src_rid, voxel_image_aligner):
         parts = []
         for row in study_rows:
             pair_study = SynapticPairStudy.from_study_id(catalog, row['RID'])
-            pair_study.retrieve_data(store)
-            parts.append(
-                get_centroids_measures_from_pair(pair_study, voxel_image_aligner)
-            )
+            try:
+                pair_study.retrieve_data(store)
+                parts.append(
+                    get_centroids_measures_from_pair(pair_study, voxel_image_aligner)
+                )
+            except Exception as e:
+                print('WARNING: got error "%s" retrieving data for %s, skipping!' % (e, pair_study.id))
 
         def concatenate(srcs):
             result = list()
@@ -203,6 +218,7 @@ This tool accepts either "ID" and "RID" column values for each argument.
     e,
     paired_csv_cli.__doc__
 ))
+        raise
         sys.exit(1)
 
 

--- a/bin/synspy-pair-csv
+++ b/bin/synspy-pair-csv
@@ -31,12 +31,6 @@ credentials = get_credential(servername)
 catalog = ErmrestCatalog('https', servername, catalog_id, credentials)
 store = HatracStore('https', servername, credentials)
 
-def get_zyx_spacing(aligner):
-    spacing = aligner._metadata['ZYX Spacing']
-    if spacing is None:
-        spacing = {'z': 0.4, 'y': 0.26, 'x': 0.26}
-    return np.array([ spacing[a] for a in 'zyx' ])
-
 def get_centroids_measures_from_pair(pair_study, voxel_image_aligner):
     image1 = ImageGrossAlignment.from_image_id(catalog, pair_study._metadata['Image 1'])
 
@@ -69,10 +63,12 @@ def get_centroids_measures_from_pair(pair_study, voxel_image_aligner):
     points_voxel_um = transform_points(xform, points_image1_um, np.float64)
     centroids[:,0:3] = centroids_zx_swap(points_voxel_um)
 
-    voxel_scale = get_zyx_spacing(voxel_image_aligner)
-    centroids /= voxel_scale
-
-    return centroids.astype(np.int32), measures, statuses.astype(np.uint8)
+    return (
+        centroids.astype(np.int32),
+        measures,
+        statuses.astype(np.uint8),
+        [ pair_study.id for i in range(centroids.shape[0]) ],
+    )
 
 def get_centroids_measures(pair_src_rid, voxel_image_aligner):
     # try to use pair_src_rid as a Cohort Analysis RID
@@ -93,10 +89,18 @@ def get_centroids_measures(pair_src_rid, voxel_image_aligner):
             parts.append(
                 get_centroids_measures_from_pair(pair_study, voxel_image_aligner)
             )
+
+        def concatenate(srcs):
+            result = list()
+            for src in srcs:
+                result.extend(src)
+            return result
+
         return (
             np.concatenate([ p[0] for p in parts ], axis=0),
             np.concatenate([ p[1] for p in parts ], axis=0),
             np.concatenate([ p[2] for p in parts ], axis=0),
+            concatenate([ p[3] for p in parts ]),
         )
     else:
         # otherwise, assume pair_src_rid is a single Synaptic Pair Study
@@ -141,18 +145,20 @@ def paired_csv_cli(voxel_img_rid, pair_src_rid):
     dump_fname = '%s/%s-%s.csv' % (dump_dir, pair_src_rid, voxel_img_rid)
 
     ref_image_aligner = ImageGrossAlignment.from_image_id(catalog, voxel_img_rid)
-    centroids, measures, statuses = get_centroids_measures(pair_src_rid, ref_image_aligner)
+    centroids, measures, statuses, study_ids = get_centroids_measures(pair_src_rid, ref_image_aligner)
 
     outf = open(dump_fname, 'w')
     writer = csv.writer(outf)
-    writer.writerow(('x', 'y', 'z', 't'))
+    writer.writerow(('x', 'y', 'z', 't', 'core intensity', 'study_id'))
 
     for i in range(centroids.shape[0]):
         writer.writerow((
-            '%d' % centroids[i,2],
-            '%d' % centroids[i,1],
-            '%d' % centroids[i,0],
-            '%d' % ({0: 0, 7: 1, 5: 2}[int(statuses[i])])
+            '%f' % centroids[i,2],
+            '%f' % centroids[i,1],
+            '%f' % centroids[i,0],
+            '%d' % ({0: 0, 7: 1, 5: 2}[int(statuses[i])]),
+            '%f' % measures[i,0],
+            study_ids[i],
         ))
 
     del writer

--- a/bin/synspy-pair-csv
+++ b/bin/synspy-pair-csv
@@ -150,7 +150,7 @@ def dump_paired_points_csv_rows(pair_src_rid, voxel_image_aligner, csvwriter, in
 
     def dump_csv(centroids, study_id):
         assert int(centroids.shape[1]) % 2 == 1, 'centroids.shape[1] is %s' % (centroids.shape[1],)
-        k = (centroids.shape[1]-1)/2
+        k = (centroids.shape[1]-1)//2
         for i in range(centroids.shape[0]):
             status = int(centroids[i,-1])
             if status == 0:

--- a/bin/synspy-pair-csv
+++ b/bin/synspy-pair-csv
@@ -23,11 +23,13 @@ catalog_id = os.getenv('SYNAPSE_CATALOG', '1')
 dump_dir = '.'
 dump_dir = os.getenv('DUMP_DIR', dump_dir)
 pairing_radius = float(os.getenv('SYNAPSE_PAIR_RADIUS', '4.0'))
+include_all = os.getenv('INCLUDE_PAIR_BEFORE', 'false').lower() == 'true'
 
 print('Effective SYNAPSE_SERVER="%s"' % servername)
 print('Effective SYNAPSE_CATALOG="%s"' % catalog_id)
 print('Effective SYNAPSE_PAIR_RADIUS="%s"' % pairing_radius)
 print('Effective DUMP_DIR="%s"' % dump_dir)
+print('Effective INCLUDE_PAIR_BEFORE="%s"' % str(include_all).lower())
 
 credentials = get_credential(servername)
 catalog = ErmrestCatalog('https', servername, catalog_id, credentials)
@@ -63,12 +65,13 @@ def get_centroids_measures_from_pair(pair_study, voxel_image_aligner):
         s2_only.shape,
     ))
 
-    # set fake override status
-    s1_only[:,-1] = 7 # force ON
-    s2_only[:,-1] = 5 # force OFF
-    s2_pair[:,-1] = 0 # unclassified
+    # set fake override status (not compatible with other synspy tools override coding)
+    s1_only[:,-1] = 1
+    s2_only[:,-1] = 2
+    s2_pair[:,-1] = 0
+    s1_pair[:,-1] = 3
     
-    centroids = np.concatenate((s1_only, s2_only, s2_pair), axis=0)
+    centroids = np.concatenate((s1_only, s2_only, s2_pair) + ((s1_pair,) if include_all else ()), axis=0)
     measures = centroids[:,3:-1]
     statuses = centroids[:,-1]
     centroids = centroids[:,0:3]
@@ -173,7 +176,7 @@ def paired_csv_cli(voxel_img_rid, pair_src_rid):
             '%f' % centroids[i,2],
             '%f' % centroids[i,1],
             '%f' % centroids[i,0],
-            '%d' % ({0: 0, 7: 1, 5: 2}[int(statuses[i])]),
+            '%d' % statuses[i],
             '%f' % measures[i,0],
             study_ids[i],
         ))

--- a/bin/synspy-pair-csv
+++ b/bin/synspy-pair-csv
@@ -23,19 +23,48 @@ catalog_id = os.getenv('SYNAPSE_CATALOG', '1')
 dump_dir = '.'
 dump_dir = os.getenv('DUMP_DIR', dump_dir)
 pairing_radius = float(os.getenv('SYNAPSE_PAIR_RADIUS', '4.0'))
-include_all = os.getenv('INCLUDE_PAIR_BEFORE', 'false').lower() == 'true'
 
 print('Effective SYNAPSE_SERVER="%s"' % servername)
 print('Effective SYNAPSE_CATALOG="%s"' % catalog_id)
 print('Effective SYNAPSE_PAIR_RADIUS="%s"' % pairing_radius)
 print('Effective DUMP_DIR="%s"' % dump_dir)
-print('Effective INCLUDE_PAIR_BEFORE="%s"' % str(include_all).lower())
 
 credentials = get_credential(servername)
 catalog = ErmrestCatalog('https', servername, catalog_id, credentials)
 store = HatracStore('https', servername, credentials)
 
 def get_centroids_measures_from_pair(pair_study, voxel_image_aligner):
+    """Return (side_by_side_data, study_id) for study.
+
+    Returns:
+    - side_by_side_data: ndarray with shape (N, 15)  [or (N, 17) if red measures are available]
+    - study_id: scalar value shared for whole result
+
+    N results comprise before-only, paired, and after-only point sets.
+
+    Fields of each points comprised of:
+    - Z coord for before point
+    - Y coord for before point
+    - X coord for before point
+    - core measure for before point
+    - hollow measure for before point
+    - DoG core measure for before point
+    - DoG hollow measure for before point
+    - [red measure for before point (in atypical multi-channel mode!)]
+    - Z coord for after point
+    - Y coord for after point
+    - X coord for after point
+    - core measure for after point
+    - hollow measure for after point
+    - DoG core measure for after point
+    - DoG hollow measure for after point
+    - [red measure for after point (in atypical multi-channel mode!)]
+    - pairing status (0: paired, 1: before-only, or 2: after-only)
+
+    Point data will be blank when not applicable, e.g. for status==1
+    the after point values are meaningless and filled with zeros.
+
+    """
     image1 = ImageGrossAlignment.from_image_id(catalog, pair_study._metadata['Image 1'])
 
     xform = None
@@ -69,25 +98,46 @@ def get_centroids_measures_from_pair(pair_study, voxel_image_aligner):
     s1_only[:,-1] = 1
     s2_only[:,-1] = 2
     s2_pair[:,-1] = 0
-    s1_pair[:,-1] = 3
-    
-    centroids = np.concatenate((s1_only, s2_only, s2_pair) + ((s1_pair,) if include_all else ()), axis=0)
-    measures = centroids[:,3:-1]
-    statuses = centroids[:,-1]
-    centroids = centroids[:,0:3]
 
-    points_image1_um = centroids_zx_swap(centroids)
-    points_voxel_um = transform_points(xform, points_image1_um, np.float64)
-    centroids[:,0:3] = centroids_zx_swap(points_voxel_um)
+    # pack centroids+measures into double width side-by-side array
+    # Z1,Y1,X1,...,Z2,Y2,X2,...
+    W = s1_only.shape[1]
+    centroids = np.zeros((
+        s1_only.shape[0] + s1_pair.shape[0] + s2_only.shape[0],
+        W*2-1
+    ), dtype=s1_only.dtype)
 
-    return (
-        centroids.astype(np.int32),
-        measures,
-        statuses.astype(np.uint8),
-        [ pair_study.id for i in range(centroids.shape[0]) ],
-    )
+    def centroids_xformed(centroids):
+        points_image1_um = centroids_zx_swap(centroids)
+        points_voxel_um = transform_points(xform, points_image1_um, np.float64)
+        return centroids_zx_swap(points_voxel_um)
 
-def get_centroids_measures(pair_src_rid, voxel_image_aligner):
+    pos0 = 0
+    pos1 = s1_only.shape[0]
+    centroids[pos0:pos1,0:3] = centroids_xformed(s1_only[:,0:3])
+    centroids[pos0:pos1,3:W-1] = s1_only[:,3:-1]
+    centroids[pos0:pos1,-1] = s1_only[:,-1] # keep s1_only override status
+
+    pos0 = pos1
+    pos1 = pos0 + s1_pair.shape[0]
+    centroids[pos0:pos1,0:3] = centroids_xformed(s1_pair[:,0:3])
+    centroids[pos0:pos1,3:W-1] = s1_pair[:,3:-1] # ignore s1_pair override status
+    centroids[pos0:pos1,W-1:W-1+3] = centroids_xformed(s2_pair[:,0:3])
+    centroids[pos0:pos1,W-1+3:2*W] = s2_pair[:,3:W] # keep s2_pair override status
+
+    pos0 = pos1
+    pos1 = pos0 + s2_only.shape[0]
+    centroids[pos0:pos1,W-1:W-1+3] = centroids_xformed(s2_only[:,0:3])
+    centroids[pos0:pos1,W-1+3:] = s2_only[:,3:W] # keep s2_only override status
+
+    return (centroids, pair_study.id)
+
+def dump_paired_points_csv_rows(pair_src_rid, voxel_image_aligner, csvwriter, include_header=True):
+    """Dump one CSV row per point pair.
+    """
+    if include_header:
+        csvwriter.writerow(('x1', 'y1', 'z1', 'core1', 'x2', 'y2', 'z2', 'core2', 't', 'study_id'))
+
     # try to use pair_src_rid as a Cohort Analysis RID
     r = catalog.get('/attribute/%(atable)s/%(ccol)s=%(crid)s/%(stable)s/RID' % {
         'atable': urlquote('Cohort Analysis_Synaptic Pair Study'),
@@ -97,37 +147,72 @@ def get_centroids_measures(pair_src_rid, voxel_image_aligner):
     })
     r.raise_for_status()
     study_rows = r.json()
+
+    def dump_csv(centroids, study_id):
+        assert int(centroids.shape[1]) % 2 == 1, 'centroids.shape[1] is %s' % (centroids.shape[1],)
+        k = (centroids.shape[1]-1)/2
+        for i in range(centroids.shape[0]):
+            status = int(centroids[i,-1])
+            if status == 0:
+                csvwriter.writerow((
+                    '%f' % centroids[i,2],
+                    '%f' % centroids[i,1],
+                    '%f' % centroids[i,0],
+                    '%f' % centroids[i,3],
+                    '%f' % centroids[i,k+2],
+                    '%f' % centroids[i,k+1],
+                    '%f' % centroids[i,k+0],
+                    '%f' % centroids[i,k+3],
+                    '%d' % status,
+                    study_id,
+                ))
+            elif status == 1:
+                csvwriter.writerow((
+                    '%f' % centroids[i,2],
+                    '%f' % centroids[i,1],
+                    '%f' % centroids[i,0],
+                    '%f' % centroids[i,3],
+                    '',
+                    '',
+                    '',
+                    '',
+                    '%d' % status,
+                    study_id,
+                ))
+            elif status == 2:
+                csvwriter.writerow((
+                    '',
+                    '',
+                    '',
+                    '',
+                    '%f' % centroids[i,k+2],
+                    '%f' % centroids[i,k+1],
+                    '%f' % centroids[i,k+0],
+                    '%f' % centroids[i,k+3],
+                    '%d' % status,
+                    study_id,
+                ))
+            else:
+                raise NotImplementedError('pair status %s not expected' % centroids[i,-1])
+
     if study_rows:
         # if we found cohort members, then combine them in an ensemble result
-        parts = []
         for row in study_rows:
             pair_study = SynapticPairStudy.from_study_id(catalog, row['RID'])
             try:
                 pair_study.retrieve_data(store)
-                parts.append(
-                    get_centroids_measures_from_pair(pair_study, voxel_image_aligner)
-                )
+                centroids, study_id = get_centroids_measures_from_pair(pair_study, voxel_image_aligner)
+                dump_csv(centroids, study_id)
             except Exception as e:
                 print('WARNING: got error "%s" retrieving data for %s, skipping!' % (e, pair_study.id))
-
-        def concatenate(srcs):
-            result = list()
-            for src in srcs:
-                result.extend(src)
-            return result
-
-        return (
-            np.concatenate([ p[0] for p in parts ], axis=0),
-            np.concatenate([ p[1] for p in parts ], axis=0),
-            np.concatenate([ p[2] for p in parts ], axis=0),
-            concatenate([ p[3] for p in parts ]),
-        )
+                raise
     else:
         # otherwise, assume pair_src_rid is a single Synaptic Pair Study
         # this will raise ValueError if it doesn't match anything...
         pair_study = SynapticPairStudy.from_study_id(catalog, pair_src_rid)
         pair_study.retrieve_data(store)
-        return get_centroids_measures_from_pair(pair_study, voxel_image_aligner)
+        centroids, study_id = get_centroids_measures_from_pair(pair_study, voxel_image_aligner)
+        dump_csv(centroids, study_id)
 
 def paired_csv_cli(voxel_img_rid, pair_src_rid):
     """Align paired synapses and write CSV output file.
@@ -152,9 +237,14 @@ def paired_csv_cli(voxel_img_rid, pair_src_rid):
          SYNAPSE_CATALOG: defaults to '1'
 
        Output CSV columns:
-         x: centroid X coord
-         y: centroid Y coord
-         z: centroid Z coord
+         x1: centroid X coord
+         y1: centroid Y coord
+         z1: centroid Z coord
+         core1: centroid core measure
+         x2: centroid X coord
+         y2: centroid Y coord
+         z2: centroid Z coord
+         core2: centroid core measure
          t: centroid status 0 (paired), 1 (pre-only), 2 (post-only)
 
        Output is written to files:
@@ -165,22 +255,9 @@ def paired_csv_cli(voxel_img_rid, pair_src_rid):
     dump_fname = '%s/%s-%s.csv' % (dump_dir, pair_src_rid, voxel_img_rid)
 
     ref_image_aligner = ImageGrossAlignment.from_image_id(catalog, voxel_img_rid)
-    centroids, measures, statuses, study_ids = get_centroids_measures(pair_src_rid, ref_image_aligner)
-
     outf = open(dump_fname, 'w')
     writer = csv.writer(outf)
-    writer.writerow(('x', 'y', 'z', 't', 'core intensity', 'study_id'))
-
-    for i in range(centroids.shape[0]):
-        writer.writerow((
-            '%f' % centroids[i,2],
-            '%f' % centroids[i,1],
-            '%f' % centroids[i,0],
-            '%d' % statuses[i],
-            '%f' % measures[i,0],
-            study_ids[i],
-        ))
-
+    dump_paired_points_csv_rows(pair_src_rid, ref_image_aligner, writer)
     del writer
     outf.close()
     print('Dumped paired synapse CSV to %s' % dump_fname)

--- a/bin/synspy-pair-csv
+++ b/bin/synspy-pair-csv
@@ -22,9 +22,11 @@ servername = os.getenv('SYNAPSE_SERVER', 'synapse.isrd.isi.edu')
 catalog_id = os.getenv('SYNAPSE_CATALOG', '1')
 dump_dir = '.'
 dump_dir = os.getenv('DUMP_DIR', dump_dir)
+pairing_radius = float(os.getenv('SYNAPSE_PAIR_RADIUS', '4.0'))
 
 print('Effective SYNAPSE_SERVER="%s"' % servername)
 print('Effective SYNAPSE_CATALOG="%s"' % catalog_id)
+print('Effective SYNAPSE_PAIR_RADIUS="%s"' % pairing_radius)
 print('Effective DUMP_DIR="%s"' % dump_dir)
 
 credentials = get_credential(servername)
@@ -49,7 +51,7 @@ def get_centroids_measures_from_pair(pair_study, voxel_image_aligner):
         # fall back to 3-point alignment
         xform = np.matmul(image1.M, voxel_image_aligner.M_inv)
 
-    s1_to_s2, s2_to_s1 = pair_study.syn_pairing_maps(max_dx_seq=(3.0,), dx_w_ratio=None, max_w_ratio=None)
+    s1_to_s2, s2_to_s1 = pair_study.syn_pairing_maps(max_dx_seq=(pairing_radius,), dx_w_ratio=None, max_w_ratio=None)
     s1_only = pair_study.get_unpaired(s1_to_s2[0,:], pair_study.s1)
     s2_only = pair_study.get_unpaired(s2_to_s1[0,:], pair_study.s2)
     s1_pair, s2_pair = pair_study.get_pairs(s1_to_s2[0,:], pair_study.s1, pair_study.s2)

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180716.0"
+__version__ = "20180807.0"

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180904.1"
+__version__ = "20180904.2"

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180904.2"
+__version__ = "20180904.3"

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180807.1"
+__version__ = "20180904.1"

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180705.2"
+__version__ = "20180705.3"

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180705.3"
+__version__ = "20180716.0"

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180705.1"
+__version__ = "20180705.2"

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180514.7"
+__version__ = "20180705.1"

--- a/synspy/__init__.py
+++ b/synspy/__init__.py
@@ -7,4 +7,4 @@
 #import analyze
 #import viewer
 
-__version__ = "20180807.0"
+__version__ = "20180807.1"

--- a/synspy/analyze/pair.py
+++ b/synspy/analyze/pair.py
@@ -360,23 +360,16 @@ class SynapticPairStudy (NucleicPairStudy):
             max_w_ratio
         )
 
-gross_points_swap = False
-
-def gross_unit_alignment(xyz_triple):
+def gross_unit_alignment(origin_xyz, yunit_xyz, zinterc_xyz):
     """Return transformation to convert XYZ points into unit space.
 
        This is a gross anatomical alignment based on three reference
        points chosen consistently in two images.
 
        Arguments:
-          xyz_triple[0,:]: P0
-          xyz_triple[1,:]: P1
-          xyz_triple[2,:]: P2
-
-       Alignment:
-          1. P0 will be translated to origin (0,0,0)
-          2. P2 will be aligned to Y-axis unit vector (0,1,0) via scale+rotate
-          3. P1 will be aligned into Z=0 plane via roll around Y-axis
+          origin_xyz: will become origin (0,0,0)
+          yunit_xyz: will become (0,1,0) to form unit vector on Y axis
+          zinterc_xyz: will become Z=0 intercept
 
        Results:
           M: 4x4 transform matrix  image microns -> unit space
@@ -384,55 +377,62 @@ def gross_unit_alignment(xyz_triple):
           length: micron per unit distance for this image
 
     """
-    v = xyz_triple
-    if gross_points_swap:
-        p1 = v[1,:].copy()
-        v[1,:] = v[2,:]
-        v[2,:] = p1
-
-    # scale to have unit length P2-P0
-    length = np.linalg.norm(v[2,:]-v[0,:])
+    # scale to have unit length
+    length = np.linalg.norm(yunit_xyz-origin_xyz)
     Ms = matrix_scale(1./length)
     Ms_inv = matrix_scale(length/1.)
-    v = transform_points(Ms, v, np.float64)
-
-    # translate to have P0 as origin
-    Mt = matrix_translate(0 - v[0,:])
-    Mt_inv = matrix_translate(0 + v[0,:])
-    v = transform_points(Mt, v, np.float64)
-
-    # rotate to align P2 to (0,1,0) on Y axis
-    Mr1_axis = np.cross(y_axis, v[2,:])
-    Mr1_angle = math.acos(
-        np.inner(y_axis, v[2,:])
-        / (np.linalg.norm(y_axis) * np.linalg.norm(v[2,:]))
+    origin_xyz, yunit_xyz, zinterc_xyz = transform_points(
+        Ms,
+        np.stack((origin_xyz, yunit_xyz, zinterc_xyz)),
+        np.float64
     )
 
+    # translate to origin
+    Mt = matrix_translate(0 - origin_xyz)
+    Mt_inv = matrix_translate(0 + origin_xyz)
+    origin_xyz, yunit_xyz, zinterc_xyz = transform_points(
+        Mt,
+        np.stack([origin_xyz, yunit_xyz, zinterc_xyz]),
+        np.float64
+    )
+
+    # rotate unit vector onto Y axis
+    Mr1_axis = np.cross(y_axis, yunit_xyz)
+    Mr1_angle = math.acos(
+        np.inner(y_axis, yunit_xyz)
+        / (np.linalg.norm(y_axis) * np.linalg.norm(yunit_xyz))
+    )
     if np.linalg.norm(Mr1_axis) > 0:
         Mr1 = matrix_rotate(Mr1_axis, Mr1_angle)
         Mr1_inv = matrix_rotate(Mr1_axis, 0 - Mr1_angle)
     else:
         Mr1 = matrix_ident()
         Mr1_inv = matrix_ident()
-
-    v = transform_points(Mr1, v, np.float64)
-
-    # roll on Y axis to place P1 into Z=0 plane
-    u1 = np.cross(y_axis, x_axis) # use X-axis as reference for XY plane
-    u2 = np.cross(y_axis, v[1,:]) # find comparable vector
-    roll = math.acos(
-        np.inner(u1, u2)
-        / (np.linalg.norm(u1) * np.linalg.norm(u2))
+    origin_xyz, yunit_xyz, zinterc_xyz = transform_points(
+        Mr1,
+        np.stack([origin_xyz, yunit_xyz, zinterc_xyz]),
+        np.float64
     )
-    if v[1,0] > 0:
-        if v[1,2] >= 0:
-            roll = 0 - roll
-    else:
-        if v[1,2] <= 0:
-            roll = 0 - roll
-    Mr2 = matrix_rotate(y_axis, roll)
-    Mr2_inv = matrix_rotate(y_axis, 0 - roll)
-    v = transform_points(Mr2, v, np.float64)
+
+    # roll on Y axis to set Z=0 intercept
+    Mr2_axis = y_axis
+    zinterc_in_xz = zinterc_xyz.copy()
+    zinterc_in_xz[1] = 0
+    Mr2_angle = math.acos(
+        np.inner(x_axis, zinterc_in_xz)
+        / (np.linalg.norm(x_axis) * np.linalg.norm(zinterc_in_xz))
+    )
+    xpos = 1 if zinterc_in_xz[0] >= 0 else -1
+    zpos = 1 if zinterc_in_xz[2] >= 0 else -1
+    if (xpos*zpos) < 0:
+        Mr2_angle = 0 - Mr2_angle
+    Mr2 = matrix_rotate(Mr2_axis, Mr2_angle)
+    Mr2_inv = matrix_rotate(Mr2_axis, 0 - Mr2_angle)
+    origin_xyz, yunit_xyz, zinterc_xyz = transform_points(
+        Mr2,
+        np.stack([origin_xyz, yunit_xyz, zinterc_xyz]),
+        np.float64
+    )
 
     # compose stacked transforms as single matrix
     M_inv = np.matmul(np.matmul(np.matmul(Mr2_inv, Mr1_inv), Mt_inv), Ms_inv)
@@ -442,7 +442,12 @@ def gross_unit_alignment(xyz_triple):
 class ImageGrossAlignment (object):
     """Local representation of one image and its alignment data.
 
-       WORK IN PROGRESS...
+       Instance Properties:
+         self.id: Image identifier
+         self.M: 4x4 transform, image_microns -> unit_space
+         self.M_inv: 4x4 transform, inverse of self.M
+         self.M_canonical: 4x4 transform, image_microns -> canonical image_microns
+         self.M_canonical_inv: 4x4 transform, inverse of self.M_canonical
     """
     @classmethod
     def from_image_id(cls, ermrest_catalog, image_id):
@@ -460,19 +465,19 @@ class ImageGrossAlignment (object):
         return (
             '/attributegroup'
             '/I:=Zebrafish:Image/ID=%(id)s;RID=%(id)s'
-            '/IS:=left(I:RID)=(Zebrafish:Alignment%%20Standard:Image)'
-            '/AS:=left(I:Alignment%%20Standard)=(Zebrafish:Alignment%%20Standard:RID)'
-            '/AI:=left(AS:Image)=(Zebrafish:Image:RID)'
+            '/AS1:=left(I:Alignment%%20Standard)=(Zebrafish:Alignment%%20Standard:RID)'
+            '/ASI1:=left(AS1:Image)=(Zebrafish:Image:RID)'
+            '/AS2:=left(ASI1:Alignment%%20Standard)=(Zebrafish:Alignment%%20Standard:RID)'
             '/$I'
             '/*'
-            ',IS_RID:=IS:RID'
-            ';AI_obj:=array(AI:*)'
-            ',AS_obj:=array(AS:*)'
+            ';ASI1_obj:=array(ASI1:*)'
+            ',AS1_obj:=array(AS1:*)'
+            ',AS2_obj:=array(AS2:*)'
         ) % {
             'id': urlquote(image_id),
         }
 
-    def __init__(self, metadata):
+    def __init__(self, metadata, swap_p1_p2=False):
         """Instantiate with record metadata retrieved from image and related entities.
 
            The exact format of metadata is an implementation detail
@@ -482,10 +487,12 @@ class ImageGrossAlignment (object):
         """
         self._metadata = metadata
         self.id = self._metadata['ID']
-        AI_obj = metadata['AI_obj']
-        AS_obj = metadata['AS_obj']
-        self.alignment_standard = AS_obj[0] if AS_obj is not None else None
-        self.alignment_standard_image = AI_obj[0] if AI_obj is not None else None
+        ASI1_obj = metadata['ASI1_obj']
+        AS1_obj = metadata['AS1_obj']
+        AS2_obj = metadata['AS2_obj']
+        self.alignment_standard = AS1_obj[0] if AS1_obj is not None else None
+        self.alignment_standard2 = AS2_obj[0] if AS2_obj is not None else None
+        self.alignment_standard_image = ASI1_obj[0] if ASI1_obj is not None else None
 
         grid_zyx = np.array([0.4, 0.26, 0.26], dtype=np.float64)
         def get_align_coord(colname, axis):
@@ -498,7 +505,7 @@ class ImageGrossAlignment (object):
             else:
                 raise ValueError('"%s" should be an object, not %s' % (colname, type(p)))
 
-        self.alignment_points_xyz = centroids_zx_swap(
+        p0, p1, p2 = centroids_zx_swap(
             np.array(
                 [
                     [
@@ -511,38 +518,71 @@ class ImageGrossAlignment (object):
                 dtype=np.float64
             ) * grid_zyx
         )
+        self.alignment_points_xyz = np.stack((p0, p1, p2))
 
-        self.M, self.M_inv, self.length = gross_unit_alignment(self.alignment_points_xyz)
+        self.swap_p1_p2 = swap_p1_p2
+        if swap_p1_p2:
+            p1, p2 = p2, p1
 
-    @property
-    def is_standard(self):
-        return self._metadata['IS_RID'] is not None
+        self.M, self.M_inv, self.length = gross_unit_alignment(p0, p1, p2)
 
     @property
     def has_standard(self):
+        """True if self references an Alignment Standard."""
         return self.alignment_standard_image is not None
 
     @property
     def M_canonical(self):
+        """4x4 transform matrix to move image microns into canonical micron space.
+
+           The canonical micron space depends on the Alignment
+           Standard and Alignment data referenced by the image.
+
+        """
         if not self.has_standard:
             raise ValueError('Image %s has no alignment standard.' % self.id)
+
+        # return stored alignment, if present
+        if self._metadata['Canonical Alignment']:
+            return np.array(self._metadata['Canonical Alignment'], dtype=np.float64)
+
+        if self.alignment_standard2 is not None:
+            raise ValueError('Image %s has a multi-hop alignment standard.' % self.id)
+
+        # compute alignment
         metadata = dict(self.alignment_standard_image)
         metadata.update({
-            'IS_RID': self.alignment_standard['RID'],
-            'AI_obj': None,
-            'AS_obj': None,
+            'ASI1_obj': None,
+            'AS1_obj': None,
+            'AS2_obj': None,
         })
-        standard = ImageGrossAlignment(metadata)
+        standard = ImageGrossAlignment(metadata, self.swap_p1_p2)
         return np.matmul(self.M, standard.M_inv)
 
-    def set_alignments(self, ermrest_catalog, alignment=None, canonical_alignment=None):
-        data = {
-            'ID': self.id,
-            'Alignment': alignment.tolist() if alignment is not None else None,
-            'Canonical Alignment': canonical_alignment.tolist() if canonical_alignment is not None else None,
-        }
-        r = ermrest_catalog.put(
-            '/attributegroup/Zebrafish:Image/ID;%s' % ','.join([ urlquote(k) for k in data if k != 'ID' ]),
-            json=[data],
-        )
-        r.raise_for_status()
+    @property
+    def M_canonical_inv(self):
+        """4x4 (inverse) transform matrix to canonical microns into image micron space.
+
+           The canonical micron space depends on the Alignment
+           Standard and Alignment data referenced by the image.
+
+        """
+        if not self.has_standard:
+            raise ValueError('Image %s has no alignment standard.' % self.id)
+
+        # return invert of stored alignment, if present
+        if self._metadata['Canonical Alignment']:
+            return np.linalg.inv(np.array(self._metadata['Canonical Alignment'], dtype=np.float64))
+
+        if self.alignment_standard2 is not None:
+            raise ValueError('Image %s has a multi-hop alignment standard.' % self.id)
+
+        # compute inverted alignment
+        metadata = dict(self.alignment_standard_image)
+        metadata.update({
+            'ASI1_obj': None,
+            'AS1_obj': None,
+            'AS2_obj': None,
+        })
+        standard = ImageGrossAlignment(metadata, self.swap_p1_p2)
+        return np.matmul(standard.M, self.M_inv)

--- a/synspy/analyze/pair.py
+++ b/synspy/analyze/pair.py
@@ -386,7 +386,7 @@ def gross_unit_alignment(xyz_triple):
     """
     v = xyz_triple
     if gross_points_swap:
-        p1 = v[1,:]
+        p1 = v[1,:].copy()
         v[1,:] = v[2,:]
         v[2,:] = p1
 


### PR DESCRIPTION
The unit01 branch has been the de facto master branch for client-side analysis for a while now.

This changed the definition of the 3-point alignment method to swap the roles of the two alignment axes in terms of which one is used to form the unit vector output axis and which is used just to compute a roll angle.

It also has revisions to the synspy-pair-csv data extraction CLI script used to dump some content for further analysis.